### PR TITLE
ui: Handle case where a pipeline's status file might be missing

### DIFF
--- a/ci/ui/assets/css/main.css
+++ b/ci/ui/assets/css/main.css
@@ -172,7 +172,8 @@ h2 {
 }
 
 .unknown {
-
+    color: #996633;
+    font-weight: bold;
 }
 
 h1.headlinegroup em {

--- a/ci/ui/js/script.js
+++ b/ci/ui/js/script.js
@@ -42,14 +42,20 @@ var generatePipelineDiv = function (groupName, data) {
     outerDiv.append(ulList);
 
     return outerDiv;
-}
+};
 
 $.get(all_status_url, function(response) {
     response.forEach(function(group) {
         Promise.all(group.pipelines.map(function(pipeline) {
             return pipeline.name;
         }).map(function(name) {
-            return $.get("/status/" + name + "_status.json");
+            return $.get("/status/" + name + "_status.json").catch(
+                function(error) {
+                    return {
+                        "pipeline_name": name,
+                        "result": "Unknown"
+                    };
+                });
         })).then(function(values) {
             return values.map(function(value) {
                 return {


### PR DESCRIPTION
If a particular pipeline's status file is missing, the code silently fails and
the entire group's results will not be shown in the UI.
This commit handles the case and displays a "Unknown" status in the UI.

Signed-off-by: Joseph Nuthalapati <njoseph@thoughtworks.com>